### PR TITLE
Parse TestDuration out of the result.txt file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+pbench-analyzer

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/openshift/origin/test/extended/cluster/metrics"
 	"github.com/redhat-performance/pbench-analyzer/pkg/result"
 	"github.com/redhat-performance/pbench-analyzer/pkg/utils"
 )
@@ -17,6 +18,7 @@ type config struct {
 	resultDir  string
 	fileHeader map[string][]string
 	hosts      []result.Host
+	Metrics    []metrics.Metrics
 	keys       []string
 }
 
@@ -92,6 +94,13 @@ func (c *config) addKeys() {
 
 // Process does the bulk of the math reading the CSV raw data and saving results
 func (c *config) Process() {
+
+	var m []metrics.Metrics
+	err := utils.GetMetics(c.searchDir, &m)
+	if err != nil {
+		fmt.Printf("Error getting Metics %v\n", err)
+	}
+	c.Metrics = m
 	c.addKeys()
 	for i, host := range c.hosts {
 		// Find each raw data CSV
@@ -131,7 +140,7 @@ func (c *config) WriteToDisk() error {
 		return err
 	}
 
-	err = utils.WriteJSON(c.resultDir, c.hosts)
+	err = utils.WriteJSON(c.resultDir, result.Result{Hosts: c.hosts, Metrics: c.Metrics})
 	if err != nil {
 		return err
 	}

--- a/pkg/result/result.go
+++ b/pkg/result/result.go
@@ -7,8 +7,14 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/openshift/origin/test/extended/cluster/metrics"
 	"github.com/redhat-performance/pbench-analyzer/pkg/stats"
 )
+
+type Result struct {
+	Hosts   []Host
+	Metrics []metrics.Metrics
+}
 
 // Host struct of a Kind has a ResultDir and a list of Results
 type Host struct {

--- a/pkg/utils/json.go
+++ b/pkg/utils/json.go
@@ -2,19 +2,24 @@ package utils
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io/ioutil"
 	"math"
+	"path"
+	"regexp"
 
+	"github.com/openshift/origin/test/extended/cluster/metrics"
 	"github.com/redhat-performance/pbench-analyzer/pkg/result"
 )
 
 // WriteJSON will output all the calculated results to JSON file
-func WriteJSON(resultDir string, hosts []result.Host) error {
+func WriteJSON(resultDir string, r result.Result) error {
 	// Remove NaN as encoding/json doesn't support NaN
-	newHosts := removeNaN(hosts)
+	r.Hosts = removeNaN(r.Hosts)
 
 	// Serialize results as JSON
-	outHosts, err := json.Marshal(newHosts)
+	outHosts, err := json.Marshal(r)
 	if err != nil {
 		return err
 	}
@@ -41,4 +46,52 @@ func removeNaN(hosts []result.Host) []result.Host {
 		}
 	}
 	return newHosts
+}
+
+func GetMetics(searchDir string, m *[]metrics.Metrics) error {
+	resultFilePath := path.Join(path.Dir(path.Clean(searchDir)), "result.txt")
+
+	bytes, err := ioutil.ReadFile(resultFilePath)
+	if err != nil {
+		return err
+	}
+
+	r := regexp.MustCompile(`{[^}]*}`)
+	if err != nil {
+		return err
+	}
+
+	// TODO import this from origin; for now it is still a private field
+	marker_name := "cluster_loader_marker"
+	var bm metrics.BaseMetrics
+	for _, jsonBytes := range r.FindAll(bytes, -1) {
+		jsonString := string(jsonBytes)
+		err := json.Unmarshal([]byte(jsonString), &bm)
+		if err != nil {
+			fmt.Printf("cannot unmarshal the line '%v' for BaseMetrics: %v\n", jsonString, err)
+		}
+
+		if marker_name == bm.Marker {
+			switch bm.Type {
+			case "metrics.TestDuration":
+				var td metrics.TestDuration
+				err := json.Unmarshal([]byte(jsonString), &td)
+				if err != nil {
+					fmt.Printf("cannot unmarshal the line '%v' for TestDuration: %v\n", jsonString, err)
+				}
+				*m = append(*m, td)
+			default:
+				fmt.Printf("unsupported metrics type %v in line: %v\n", bm.Type, jsonString)
+			}
+		} else if err == nil {
+			fmt.Printf("no marker in the line: %v\n", jsonString)
+		}
+	}
+
+	if len(*m) == 0 {
+		return errors.New(fmt.Sprintf("Cannot find metrics in file: %s",
+			resultFilePath))
+	}
+
+	return nil
 }


### PR DESCRIPTION
This is part of https://trello.com/c/mChdFZLq/829-tools-add-pbench-stdout-file-parsing-for-misc-metrics-to-pbench-scraper
The TestDuration object is read from the result.txt file and saved
in out.json file in output folder.

We have not yet handle the cvs output yet.