### PR TITLE
Parse TestDuration out of the result.txt file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+pbench-analyzer

--- a/cmd/compare/main.go
+++ b/cmd/compare/main.go
@@ -51,34 +51,39 @@ func main() {
 		return
 	}
 
-	if !areResultsSimilar(oldRun, newRun) {
+	if !areHostResultsSimilar(oldRun.Hosts, newRun.Hosts) {
 		fmt.Fprintf(os.Stderr, "Results do not have the same number of hosts and/or results per host.\n")
 		return
 	}
 
-	for i := range oldRun {
-		for j := range oldRun[i].Results {
-			if newRun[i].Results[j].Pct95 > oldRun[i].Results[j].Pct95*(1+stdDev) ||
-				newRun[i].Results[j].Pct95 < oldRun[i].Results[j].Pct95*(1-stdDev) {
-				fmt.Printf("%s: Out of spec %s process with %s\n", newRun[i].Kind, newRun[i].Results[j].Kind, newRun[i].Results[j].Resource)
+	for i := range oldRun.Hosts {
+		for j := range oldRun.Hosts[i].Results {
+			if newRun.Hosts[i].Results[j].Pct95 > oldRun.Hosts[i].Results[j].Pct95*(1+stdDev) ||
+				newRun.Hosts[i].Results[j].Pct95 < oldRun.Hosts[i].Results[j].Pct95*(1-stdDev) {
+				fmt.Printf("%s: Out of spec %s process with %s\n", newRun.Hosts[i].Kind, newRun.Hosts[i].Results[j].Kind, newRun.Hosts[i].Results[j].Resource)
 				return
 			}
 		}
 	}
+
+	// TODO compare metrics?
 }
 
-func readResultJSON(file string) ([]result.Host, error) {
-	var res []result.Host
+func readResultJSON(file string) (*result.Result, error) {
+	var res result.Result
 	raw, err := ioutil.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}
 
-	json.Unmarshal(raw, &res)
-	return res, nil
+	err = json.Unmarshal(raw, &res)
+	if err != nil {
+		return nil, err
+	}
+	return &res, nil
 }
 
-func areResultsSimilar(old, new []result.Host) bool {
+func areHostResultsSimilar(old, new []result.Host) bool {
 	if len(old) != len(new) {
 		return false
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/openshift/origin/test/extended/cluster/metrics"
 	"github.com/redhat-performance/pbench-analyzer/pkg/result"
 	"github.com/redhat-performance/pbench-analyzer/pkg/utils"
 )
@@ -17,6 +18,7 @@ type config struct {
 	resultDir  string
 	fileHeader map[string][]string
 	hosts      []result.Host
+	Metrics    []metrics.Metrics
 	keys       []string
 }
 
@@ -122,6 +124,13 @@ func (c *config) Process() {
 			}
 		}
 	}
+
+	var m []metrics.Metrics
+	err := utils.GetMetics(c.searchDir, &m)
+	if err != nil {
+		fmt.Printf("Error getting Metics %v\n", err)
+	}
+	c.Metrics = m
 }
 
 // WriteToDisk will write the results to disk as a CSV and a JSON file
@@ -131,7 +140,7 @@ func (c *config) WriteToDisk() error {
 		return err
 	}
 
-	err = utils.WriteJSON(c.resultDir, c.hosts)
+	err = utils.WriteJSON(c.resultDir, result.Result{Hosts: c.hosts, Metrics: c.Metrics})
 	if err != nil {
 		return err
 	}

--- a/pkg/result/result.go
+++ b/pkg/result/result.go
@@ -7,8 +7,14 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/openshift/origin/test/extended/cluster/metrics"
 	"github.com/redhat-performance/pbench-analyzer/pkg/stats"
 )
+
+type Result struct {
+	Hosts   []Host
+	Metrics []metrics.Metrics
+}
 
 // Host struct of a Kind has a ResultDir and a list of Results
 type Host struct {

--- a/pkg/utils/json.go
+++ b/pkg/utils/json.go
@@ -2,19 +2,23 @@ package utils
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"math"
+	"path"
+	"regexp"
 
+	"github.com/openshift/origin/test/extended/cluster/metrics"
 	"github.com/redhat-performance/pbench-analyzer/pkg/result"
 )
 
 // WriteJSON will output all the calculated results to JSON file
-func WriteJSON(resultDir string, hosts []result.Host) error {
+func WriteJSON(resultDir string, r result.Result) error {
 	// Remove NaN as encoding/json doesn't support NaN
-	newHosts := removeNaN(hosts)
+	r.Hosts = removeNaN(r.Hosts)
 
 	// Serialize results as JSON
-	outHosts, err := json.Marshal(newHosts)
+	outHosts, err := json.Marshal(r)
 	if err != nil {
 		return err
 	}
@@ -41,4 +45,42 @@ func removeNaN(hosts []result.Host) []result.Host {
 		}
 	}
 	return newHosts
+}
+
+func GetMetics(searchDir string, m *[]metrics.Metrics) error {
+	resultFilePath := path.Join(path.Dir(path.Clean(searchDir)), "result.txt")
+
+	bytes, err := ioutil.ReadFile(resultFilePath)
+	if err != nil {
+		return err
+	}
+
+	// any line start with '{' and and with '}'
+	r := regexp.MustCompile(`(?m:^{.*}$)`)
+
+	var bm metrics.BaseMetrics
+	for _, jsonBytes := range r.FindAll(bytes, -1) {
+		err := json.Unmarshal(jsonBytes, &bm)
+		if err != nil {
+			fmt.Printf("cannot unmarshal the line '%v' for BaseMetrics: %v\n", string(jsonBytes), err)
+		}
+
+		switch bm.Type {
+		case "metrics.TestDuration":
+			var td metrics.TestDuration
+			err := json.Unmarshal(jsonBytes, &td)
+			if err != nil {
+				fmt.Printf("cannot unmarshal the line '%v' for TestDuration: %v\n", string(jsonBytes), err)
+			}
+			*m = append(*m, td)
+		default:
+			fmt.Printf("unsupported metrics type %v in line: %v\n", bm.Type, string(jsonBytes))
+		}
+	}
+
+	if len(*m) == 0 {
+		fmt.Printf("Cannot find metrics in file: %s\n", resultFilePath)
+	}
+
+	return nil
 }

--- a/pkg/utils/json.go
+++ b/pkg/utils/json.go
@@ -62,7 +62,7 @@ func GetMetics(searchDir string, m *[]metrics.Metrics) error {
 	for _, jsonBytes := range r.FindAll(bytes, -1) {
 		err := json.Unmarshal(jsonBytes, &bm)
 		if err != nil {
-			fmt.Printf("cannot unmarshal the line '%v' for BaseMetrics: %v\n", string(jsonBytes), err)
+			fmt.Printf("cannot unmarshal the line '%s' for BaseMetrics: %v\n", jsonBytes, err)
 		}
 
 		switch bm.Type {
@@ -70,11 +70,11 @@ func GetMetics(searchDir string, m *[]metrics.Metrics) error {
 			var td metrics.TestDuration
 			err := json.Unmarshal(jsonBytes, &td)
 			if err != nil {
-				fmt.Printf("cannot unmarshal the line '%v' for TestDuration: %v\n", string(jsonBytes), err)
+				fmt.Printf("cannot unmarshal the line '%s' for TestDuration: %v\n", jsonBytes, err)
 			}
 			*m = append(*m, td)
 		default:
-			fmt.Printf("unsupported metrics type %v in line: %v\n", bm.Type, string(jsonBytes))
+			fmt.Printf("unsupported metrics type %v in line: %s\n", bm.Type, jsonBytes)
 		}
 	}
 


### PR DESCRIPTION
This is part of https://trello.com/c/mChdFZLq/829-tools-add-pbench-stdout-file-parsing-for-misc-metrics-to-pbench-scraper
The TestDuration object is read from the result.txt file and saved
in out.json file in output folder.

We have not yet handle the cvs output yet.