### PR TITLE
Compare non-identical results

### DIFF
--- a/cmd/scraper/main.go
+++ b/cmd/scraper/main.go
@@ -12,9 +12,9 @@ var searchDir, resultDir, processString, netString, blockString string
 func initFlags() {
 	flag.StringVar(&searchDir, "i", "/var/lib/pbench-agent/benchmark_result/tools-default/", "pbench run result directory to parse")
 	flag.StringVar(&resultDir, "o", "/tmp/", "output directory for parsed CSV result data")
-	flag.StringVar(&processString, "proc", "openshift_start_master_api,openshift_start_master_controll,openshift_start_node,/etcd", "list of processes to gather")
-	flag.StringVar(&blockString, "blkdev", "", "List of block devices")
-	flag.StringVar(&netString, "netdev", "", "List of network devices")
+	flag.StringVar(&processString, "proc", "openshift_start_master_api_,openshift_start_master_controllers_,hyperkube_kubelet_,etcd,dockerd-current_,elasticsearc,prometheus_,systemd_--switched-root,openshift_start_network_,ovs-vswitchd_unix,openshift-router,fluentd,kibana,heapster,crio", "list of processes to gather")
+	flag.StringVar(&blockString, "blkdev", "sda-write,sda-read,vda-write,vda-read,xvda-write,xvda-read,xvdb-write,xvdb-read,nvme0n1-write,nvme0n1-read", "List of block devices")
+	flag.StringVar(&netString, "netdev", "eth0-rx,eth0-tx", "List of network devices")
 	flag.Parse()
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -61,7 +61,7 @@ func (c *config) addHeaders(blockString, netString, processString string) {
 func (c *config) InitHosts() {
 	// This regexp matches the prefix to each pbench host result directory name
 	// which indicates host type. (ie. svt-master-1:pbench-benchmark-001/)
-	hostRegex := regexp.MustCompile(`svt[_-][elmn]\w*[_-]\d`)
+	hostRegex := regexp.MustCompile(`svt[_-][ceilmn]\w*[_-]\d`)
 	// Return directory listing of searchDir
 	dirList, err := ioutil.ReadDir(c.searchDir)
 	if err != nil {
@@ -126,11 +126,12 @@ func (c *config) Process() {
 	}
 
 	var m []metrics.Metrics
-	err := utils.GetMetics(c.searchDir, &m)
+	err := utils.GetMetrics(c.searchDir, &m)
 	if err != nil {
-		fmt.Printf("Error getting Metics %v\n", err)
+		fmt.Printf("Error getting Metrics: %v\n", err)
+	} else {
+		c.Metrics = m
 	}
-	c.Metrics = m
 }
 
 // WriteToDisk will write the results to disk as a CSV and a JSON file

--- a/pkg/result/result.go
+++ b/pkg/result/result.go
@@ -13,7 +13,7 @@ import (
 
 type Result struct {
 	Hosts   []Host
-	Metrics []metrics.Metrics
+	Metrics []metrics.BaseMetrics
 }
 
 // Host struct of a Kind has a ResultDir and a list of Results

--- a/pkg/utils/json.go
+++ b/pkg/utils/json.go
@@ -47,7 +47,7 @@ func removeNaN(hosts []result.Host) []result.Host {
 	return newHosts
 }
 
-func GetMetics(searchDir string, m *[]metrics.Metrics) error {
+func GetMetrics(searchDir string, m *[]metrics.Metrics) error {
 	resultFilePath := path.Join(path.Dir(path.Clean(searchDir)), "result.txt")
 
 	bytes, err := ioutil.ReadFile(resultFilePath)
@@ -79,7 +79,7 @@ func GetMetics(searchDir string, m *[]metrics.Metrics) error {
 	}
 
 	if len(*m) == 0 {
-		fmt.Printf("Cannot find metrics in file: %s\n", resultFilePath)
+		return fmt.Errorf("cannot find metrics in file: %s\n", resultFilePath)
 	}
 
 	return nil


### PR DESCRIPTION
Changes:
- Change file reading error to add a bit more information
- Remove check to ensure that all hosts and all results are present in both samples
- Change comparison to fetch matching result rather than comparing sorted indexes