### PR TITLE
Add comparison back to 3.9 results

### DIFF
--- a/cmd/compare/main.go
+++ b/cmd/compare/main.go
@@ -12,6 +12,7 @@ import (
 
 var oldFile, newFile string
 var stdDev float64
+var procAlias map[string]string
 
 func initFlags() {
 	flag.StringVar(&oldFile, "old", "", "Previous run summary")
@@ -25,6 +26,8 @@ func main() {
 	var files []string
 	files = append(files, oldFile)
 	files = append(files, newFile)
+	procAlias = make(map[string]string)
+	procAlias["openshift_start_node_"] = "hyperkube_kubelet_"
 
 	if oldFile == "" && newFile == "" {
 		fmt.Fprintf(os.Stderr, "Must specify both old and new run data:\n")
@@ -84,7 +87,8 @@ func getHostIndex(hostResult []result.Host, kind string) (int, error) {
 
 func getResultIndex(hostResult result.Host, resultItem result.ResultType) (int, error) {
 	for r := range hostResult.Results {
-		if hostResult.Results[r].Kind == resultItem.Kind &&
+		if (hostResult.Results[r].Kind == resultItem.Kind ||
+			hostResult.Results[r].Kind == procAlias[resultItem.Kind]) &&
 			hostResult.Results[r].Resource == resultItem.Resource {
 			return r, nil
 		}

--- a/cmd/scraper/main.go
+++ b/cmd/scraper/main.go
@@ -12,7 +12,7 @@ var searchDir, resultDir, processString, netString, blockString string
 func initFlags() {
 	flag.StringVar(&searchDir, "i", "/var/lib/pbench-agent/benchmark_result/tools-default/", "pbench run result directory to parse")
 	flag.StringVar(&resultDir, "o", "/tmp/", "output directory for parsed CSV result data")
-	flag.StringVar(&processString, "proc", "openshift_start_master_api_,openshift_start_master_controllers_,hyperkube_kubelet_,etcd,dockerd-current_,elasticsearc,prometheus_,systemd_--switched-root,openshift_start_network_,ovs-vswitchd_unix,openshift-router,fluentd,kibana,heapster,crio", "list of processes to gather")
+	flag.StringVar(&processString, "proc", "openshift_start_master_api_,openshift_start_master_controll,hyperkube_kubelet_,openshift_start_node_,etcd,dockerd-current_,elasticsearc,prometheus_,systemd_--switched-root,openshift_start_network_,ovs-vswitchd_unix,openshift-router,fluentd,kibana,heapster,crio", "list of processes to gather")
 	flag.StringVar(&blockString, "blkdev", "sda-write,sda-read,vda-write,vda-read,xvda-write,xvda-read,xvdb-write,xvdb-read,nvme0n1-write,nvme0n1-read", "List of block devices")
 	flag.StringVar(&netString, "netdev", "eth0-rx,eth0-tx", "List of network devices")
 	flag.Parse()


### PR DESCRIPTION
Needed an alias for the node process name. Also added 3.9 compatible process names to the default scrape list.